### PR TITLE
fix Transifex escape chars

### DIFF
--- a/language/de.json
+++ b/language/de.json
@@ -48,7 +48,7 @@
       "description": "Diese Optionen legen fest, wie sich die Aufgabe verhält.",
       "fields": [
         {
-          "label": "\\\"Wiederholen\\\"-Button anzeigen"
+          "label": "\"Wiederholen\"-Button anzeigen"
         },
         {
           "label": "Rückwärts-Navigation ausstellen",
@@ -61,19 +61,19 @@
       ]
     },
     {
-      "label": "Text für den \\\"Umdrehen\\\"-Button",
+      "label": "Text für den \"Umdrehen\"-Button",
       "default": "Umdrehen"
     },
     {
-      "label": "Text für den \\\"Weiter\\\"-Button",
+      "label": "Text für den \"Weiter\"-Button",
       "default": "Weiter"
     },
     {
-      "label": "Text für den \\\"Zurück\\\"-Button",
+      "label": "Text für den \"Zurück\"-Button",
       "default": "Zurück"
     },
     {
-      "label": "Text für den \\\"Wiederholen\\\"-Button",
+      "label": "Text für den \"Wiederholen\"-Button",
       "default": "Wiederholen"
     },
     {


### PR DESCRIPTION
When entering " in Transifex, they don't have to be escaped. Fixed the unecessary escape characters.