### PR TITLE
Update media capabilities

### DIFF
--- a/css/dialogcards.css
+++ b/css/dialogcards.css
@@ -18,9 +18,20 @@
   outline: 0;
 }
 
+.h5p-dialogcards .h5p-dialogcards-card-text-area.hide {
+  display: none;
+}
+
 .h5p-dialogcards {
   overflow: hidden;
   position: relative;
+}
+
+.h5p-dialogcards .h5p-dialogcards-warning {
+  width: auto;
+  margin: 16px;
+  font-size: 1.5em;
+  text-align: center;
 }
 
 .h5p-no-frame .h5p-dialogcards .h5p-dialogcards-title,

--- a/css/dialogcards.css
+++ b/css/dialogcards.css
@@ -100,11 +100,11 @@
   height: 2.25em;
 }
 
-.h5p-dialogcards .h5p-dialogcards-image-wrapper {
+.h5p-dialogcards .h5p-dialogcards-media-wrapper {
   position: relative;
 }
 
-.h5p-dialogcards .h5p-dialogcards-image-wrapper > .h5p-dialogcards-image {
+.h5p-dialogcards .h5p-dialogcards-media-wrapper > .h5p-dialogcards-image {
   text-align: center;
   max-height: 100%;
   max-width: 100%;
@@ -115,6 +115,15 @@
   -webkit-transform: translate(-50%, -50%);
   -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
+}
+
+.h5p-dialogcards .h5p-dialogcards-media-wrapper > .h5p-dialogcards-video {
+  line-height: 0;
+  margin: auto;
+}
+
+.h5p-dialogcards .h5p-dialogcards-media-wrapper > .h5p-dialogcards-video > .h5p-video {
+  width: 100%;
 }
 
 .h5p-dialogcards .h5p-audio-inner.hide {

--- a/js/dialogcards.js
+++ b/js/dialogcards.js
@@ -206,7 +206,6 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
     }
 
     // Make sure we have an index
-
     if (index === undefined) {
       index = self.$current.index();
     }
@@ -254,9 +253,7 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
       }
     };
 
-
     for (var i = 0; i < cards.length; i++) {
-
       // Load cards progressively
       if (i >= initLoad) {
         break;

--- a/js/dialogcards.js
+++ b/js/dialogcards.js
@@ -54,6 +54,11 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
       }
     }, params);
 
+    // Filter out empty cards
+    self.params.dialogs = self.params.dialogs.filter(function (dialog) {
+      return dialog.media || (dialog.text && dialog.text.trim !== '') || (dialog.answer && dialog.answer.trim() !== '');
+    });
+
     self._current = -1;
     self._turned = [];
     self.$medias = [];
@@ -71,6 +76,16 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
    */
   C.prototype.attach = function ($container) {
     var self = this;
+
+    // No cards
+    if (self.params.dialogs.length === 0) {
+      $container
+        .addClass('h5p-dialogcards')
+        .append('<div class="h5p-dialogcards h5p-dialogcards-warning">I really need at least one card with content :-)</div>');
+      this.trigger('resize');
+      return;
+    }
+
     var title = $('<div>' + self.params.title + '</div>').text().trim();
 
     self.$inner = $container
@@ -352,7 +367,7 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
       'html': card.text
     }).appendTo($cardText);
 
-    if (!card.text || !card.text.length) {
+    if ((!card.text || !card.text.length) && (!card.answer || !card.answer.length)) {
       $cardText.addClass('hide');
     }
 

--- a/js/dialogcards.js
+++ b/js/dialogcards.js
@@ -148,7 +148,7 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
   };
 
   /**
-   * Called when all cards has been loaded.
+   * Called when all cards have been loaded.
    */
   C.prototype.updateImageSize = function () {
     var self = this;
@@ -191,7 +191,7 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
    * @param {String} [side=front] Which side of the card
    * @param {Number} [index] Index of card
    */
-  C.prototype.addTipToCard = function($card, side, index) {
+  C.prototype.addTipToCard = function ($card, side, index) {
     var self = this;
 
     // Make sure we have a side
@@ -585,7 +585,7 @@ H5P.Dialogcards = (function ($, Audio, JoubelUI) {
 
   /**
    * Stop audio of card with cardindex
-
+   *
    * @param {Number} cardIndex Index of card
    */
   C.prototype.stopAudio = function (cardIndex) {

--- a/language/.en.json
+++ b/language/.en.json
@@ -27,11 +27,8 @@
             "description": "Hint for the second part of the dialogue"
           },
           {
-            "label": "Image",
-            "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Audio files"

--- a/language/ar.json
+++ b/language/ar.json
@@ -27,11 +27,8 @@
             "description": "تلميح للجزء الثاني من الحوار"
           },
           {
-            "label": "Image",
-            "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Audio files"

--- a/language/bs.json
+++ b/language/bs.json
@@ -27,11 +27,8 @@
             "description": "Hint for the second part of the dialogue"
           },
           {
-            "label": "Image",
-            "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Audio files"

--- a/language/da.json
+++ b/language/da.json
@@ -27,11 +27,8 @@
             "description": "Hint til anden del af dialogen"
           },
           {
-            "label": "Billede",
-            "description": "Valgfrit billede til kortet. (Kortet kan indeholde enten billede eller tekst, eller begge dele)."
-          },
-          {
-            "label": "Alternativ tekst til billedet"
+            "label": "Medier",
+            "description": "Valgfrie medier til kortet. (Kortet kan indeholde enten billede eller video, kun tekst, eller begge dele)"
           },
           {
             "label": "Lydfiler"

--- a/language/de.json
+++ b/language/de.json
@@ -27,11 +27,8 @@
             "description": "Hinweis für den zweiten Teil des Dialogs"
           },
           {
-            "label": "Bild",
-            "description": "Optionales Bild für die Karte. (Die Karte kann ein Bild benutzen, Text oder beides.)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Medien",
+            "description": "Optionale Medien für die Karte. (Die Karte kann ein Bild oder Video benutzen, nur Text oder beides.)"
           },
           {
             "label": "Audio files"

--- a/language/fi.json
+++ b/language/fi.json
@@ -27,11 +27,8 @@
             "description": "Tekstisisältö kortin kääntöpuolelle"
           },
           {
-            "label": "Kuva",
-            "description": "Valinnainen kuva kortille. Kortti voi olla vain kuva, tekstiä tai molemmat."
-          },
-          {
-            "label": "Vaihtoehtoinen teksti kuvalle"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Äänitiedostot"

--- a/language/fr.json
+++ b/language/fr.json
@@ -27,11 +27,8 @@
             "description": "Texte pour le dos de la carte"
           },
           {
-            "label": "Image",
-            "description": "Image facultative pour la carte. (Une carte peut contenir une image seule, un texte seul ou les deux combinés)"
-          },
-          {
-            "label": "Texte alternatif pour l'image"
+            "label": "Médias",
+            "description": "Médias facultatives pour la carte. (Une carte peut contenir une image seule ou une vidéo seule, un texte seul ou les deux combinés)"
           },
           {
             "label": "Fichiers audio"

--- a/language/it.json
+++ b/language/it.json
@@ -27,11 +27,8 @@
             "description": "Suggerimento per la seconda parte del dialogo"
           },
           {
-            "label": "Image",
-            "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Audio files"

--- a/language/ja.json
+++ b/language/ja.json
@@ -27,11 +27,8 @@
             "description": "Hint for the second part of the dialogue"
           },
           {
-            "label": "Image",
-            "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Audio files"

--- a/language/nb.json
+++ b/language/nb.json
@@ -27,11 +27,8 @@
             "description": "Nøkkelord til neste del av dialogen"
           },
           {
-            "label": "Bilde",
-            "description": "Valgfritt bilde for kortet.(Kortet kan bruke kun bilde, kun tekst, eller begge)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Medier",
+            "description": "Valgfrie medier for kortet. (Kortet kan bruke kun bilde eller video, kun tekst, eller begge)"
           },
           {
             "label": "Audio files"

--- a/language/nl.json
+++ b/language/nl.json
@@ -27,11 +27,8 @@
             "description": "Hint voor het tweede deel van het dialoog"
           },
           {
-            "label": "Afbeelding",
-            "description": "Optionele afbeelding voor de kaart. (De kaart mag alleen een afbeelding gebruiken, alleen een tekst of allebei)"
-          },
-          {
-            "label": "Alternatieve tekst voor een afbeelding"
+            "label": "Media",
+            "description": "Optionele media voor de kaart. (De kaart mag alleen een afbeelding of video gebruiken, alleen een tekst of allebei)"
           },
           {
             "label": "Audio bestanden"

--- a/language/nn.json
+++ b/language/nn.json
@@ -27,11 +27,8 @@
             "description": "Nøkkelord til neste delen av dialogen"
           },
           {
-            "label": "Bilete",
-            "description": "Valfritt bilete for kortet.(Korta kan bruka berre bilete, berre tekst, eller begge)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Medier",
+            "description": "Valfrie medier for kortet. (Korta kan bruka berre bilete eller video, berre tekst, eller begge)"
           },
           {
             "label": "Audio files"

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -27,11 +27,8 @@
             "description": "Texto da segunda parte do diálogo"
           },
           {
-            "label": "Imagem",
-            "description": "Imagem opcional para o cartão. (O cartão pode conter apenas uma imagem, apenas um texto, ou ambos)"
-          },
-          {
-            "label": "Texto alternativo para a imagem"
+            "label": "Mídias",
+            "description": "Mídias opcionais para o cartão. (O cartão pode conter apenas uma imagem ou um vídeo, apenas um texto, ou ambos)"
           },
           {
             "label": "Arquivos de áudio"

--- a/language/pt.json
+++ b/language/pt.json
@@ -27,11 +27,8 @@
             "description": "Texto da segunda parte do diálogo"
           },
           {
-            "label": "Imagem",
-            "description": "Imagem opcional para o cartão. (O cartão pode conter apenas uma imagem, apenas um texto, ou ambos)"
-          },
-          {
-            "label": "Texto alternativo para a imagem"
+            "label": "Mídias",
+            "description": "Mídias opcionais para o cartão. (O cartão pode conter apenas uma imagem ou um vídeo, apenas um texto, ou ambos)"
           },
           {
             "label": "Arquivos de áudio"

--- a/language/sv.json
+++ b/language/sv.json
@@ -27,11 +27,8 @@
             "description": "Hint for the second part of the dialogue"
           },
           {
-            "label": "Image",
-            "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-          },
-          {
-            "label": "Alternative text for the image"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Audio files"

--- a/language/tr.json
+++ b/language/tr.json
@@ -27,11 +27,8 @@
             "description": "Diyaloğun ikinci bölümü için ipucu"
           },
           {
-            "label": "Görsel",
-            "description": "Kart için isteğe bağlı görsel. (Kart sadece bir görsel, sadece bir metin ya da ikisini birden içerebilir.)"
-          },
-          {
-            "label": "Görsel için alternatif metin"
+            "label": "Media",
+            "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
           },
           {
             "label": "Ses dosyaları"

--- a/library.json
+++ b/library.json
@@ -2,8 +2,8 @@
   "title": "Dialog Cards",
   "description": "Makes it possible to create learning tasks for your site visitors.",
   "majorVersion": 1,
-  "minorVersion": 7,
-  "patchVersion": 2,
+  "minorVersion": 8,
+  "patchVersion": 0,
   "runnable": 1,
   "author": "Joubel",
   "license": "MIT",
@@ -40,6 +40,16 @@
       "machineName": "H5P.Audio",
       "majorVersion": 1,
       "minorVersion": 3
+    },
+    {
+      "machineName": "H5P.Image",
+      "majorVersion": 1,
+      "minorVersion": 1
+    },
+    {
+      "machineName": "H5P.Video",
+      "majorVersion": 1,
+      "minorVersion": 5
     }
   ],
   "editorDependencies": [

--- a/semantics.json
+++ b/semantics.json
@@ -77,19 +77,16 @@
           "description": "Hint for the second part of the dialogue"
         },
         {
-          "name": "image",
-          "type": "image",
-          "label": "Image",
+          "name": "media",
+          "type": "library",
+          "label": "Media",
           "importance": "high",
+          "options": [
+            "H5P.Image 1.1",
+            "H5P.Video 1.5"
+          ],
           "optional": true,
-          "description": "Optional image for the card. (The card may use just an image, just a text or both)"
-        },
-        {
-          "name": "imageAltText",
-          "type": "text",
-          "label": "Alternative text for the image",
-          "importance": "high",
-          "optional": true
+          "description": "Optional media for the card. (The card may use just an image or video, just a text or both)"
         },
         {
           "name": "audio",

--- a/semantics.json
+++ b/semantics.json
@@ -59,6 +59,7 @@
             "em"
           ],
           "label": "Text",
+          "optional": true,
           "importance": "high",
           "description": "Hint for the first part of the dialogue"
         },
@@ -73,6 +74,7 @@
             "em"
           ],
           "label": "Answer",
+          "optional": true,
           "importance": "high",
           "description": "Hint for the second part of the dialogue"
         },

--- a/upgrades.js
+++ b/upgrades.js
@@ -35,6 +35,70 @@ H5PUpgrades['H5P.Dialogcards'] = (function () {
         };
 
         finished(null, parameters, extrasOut);
+      },
+
+      8: function (parameters, finished, extras) {
+        // Update image items
+        if (parameters.dialogs) {
+          parameters.dialogs.forEach(function (dialog) {
+            if (!dialog.image) {
+              return; // skip
+            }
+
+            const newImage = {
+              library: 'H5P.Image 1.1',
+              // Avoid using H5P.createUUID since this is an upgrade script and H5P function may change
+              subContentId: 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (char) {
+                const random = Math.random()*16|0, newChar = char === 'x' ? random : (random&0x3|0x8);
+                return newChar.toString(16);
+              }),
+              params: {
+                alt: dialog.imageAltText || '',
+                contentName: 'Image',
+                title: dialog.imageAltText || '',
+                file: dialog.image
+              },
+              extras: {}
+            };
+
+            // Move copyright to metadata
+            const copyright = dialog.image.copyright;
+            if (copyright) {
+              let years = [];
+              if (copyright.year) {
+                // Try to find start and end year
+                years = copyright.year
+                  .replace(' ', '')
+                  .replace('--', '-') // Check for LaTeX notation
+                  .split('-');
+              }
+              const yearFrom = (years.length > 0) ? new Date(years[0]).getFullYear() : undefined;
+              const yearTo = (years.length > 0) ? new Date(years[1]).getFullYear() : undefined;
+
+              // Build metadata object
+              newImage.extras.metadata = {
+                title: copyright.title,
+                authors: (copyright.author) ? [{name: copyright.author, role: ''}] : undefined,
+                source: copyright.source,
+                yearFrom: isNaN(yearFrom) ? undefined : yearFrom,
+                yearTo: isNaN(yearTo) ? undefined : yearTo,
+                license: copyright.license,
+                licenseVersion: copyright.version
+              };
+
+              if (newImage.params.file) {
+                delete newImage.params.file.copyright;
+              }
+            }
+
+            dialog.media = newImage;
+
+            delete dialog.image;
+            delete dialog.imageAltText;
+          });
+        }
+
+        finished(null, parameters, extras);
       }
     }
   };


### PR DESCRIPTION
- Add option to include video in DialogCards. For use case details and demo, cmp https://www.olivertacke.de/labs/2018/09/22/videos-in-h5p-dialog-cards/
- Use H5P.Image instead of image widget (to have alt tag for a11y without special field)

Note: Already uses not yet released libraries as dependencies to support metadata.