### PR TITLE
Fix setting focus on iOS13

### DIFF
--- a/src/scripts/h5p-dialogcards-summary-screen.js
+++ b/src/scripts/h5p-dialogcards-summary-screen.js
@@ -224,7 +224,10 @@ class SummaryScreen {
    */
   show() {
     this.container.classList.remove('h5p-dialogcards-gone');
-    this.fields['button'].focus();
+    // iOS13 requires DOM to be visible to focus
+    setTimeout(() => {
+      this.fields['button'].focus();
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
Fixes problem reported at [https://h5p.org/node/620069](https://h5p.org/node/620069). On iOS13, when setting the button focus before the DOM container is visible, the browser crashes.

