### PR TITLE
Fix unused buttons interfering in normal mode

### DIFF
--- a/src/scripts/h5p-dialogcards-card.js
+++ b/src/scripts/h5p-dialogcards-card.js
@@ -23,6 +23,9 @@ class Card {
       'role': 'group',
       'tabindex': '-1'
     });
+
+    this.$cardWrapper.addClass('h5p-dialogcards-mode-' + this.params.mode);
+
     if (this.params.mode !== 'repetition') {
       this.$cardWrapper.attr('aria-labelledby', 'h5p-dialogcards-progress-' + H5P.Dialogcards.idCounter)
     }
@@ -174,26 +177,28 @@ class Card {
       'html': this.params.answer
     }).appendTo($cardFooter);
 
-    this.$buttonShowSummary = H5P.JoubelUI.createButton({
-      'class': 'h5p-dialogcards-show-summary h5p-dialogcards-button-gone',
-      'html': this.params.showSummary
-    }).appendTo($cardFooter);
+    if (this.params.mode === 'repetition') {
+      this.$buttonShowSummary = H5P.JoubelUI.createButton({
+        'class': 'h5p-dialogcards-show-summary h5p-dialogcards-button-gone',
+        'html': this.params.showSummary
+      }).appendTo($cardFooter);
 
-    this.$buttonIncorrect = H5P.JoubelUI.createButton({
-      'class': 'h5p-dialogcards-answer-button',
-      'html': this.params.incorrectAnswer
-    }).addClass('incorrect')
-      .addClass(classesRepetition)
-      .attr('tabindex', attributeTabindex)
-      .appendTo($cardFooter);
+      this.$buttonIncorrect = H5P.JoubelUI.createButton({
+        'class': 'h5p-dialogcards-answer-button',
+        'html': this.params.incorrectAnswer
+      }).addClass('incorrect')
+        .addClass(classesRepetition)
+        .attr('tabindex', attributeTabindex)
+        .appendTo($cardFooter);
 
-    this.$buttonCorrect = H5P.JoubelUI.createButton({
-      'class': 'h5p-dialogcards-answer-button',
-      'html': this.params.correctAnswer
-    }).addClass('correct')
-      .addClass(classesRepetition)
-      .attr('tabindex', attributeTabindex)
-      .appendTo($cardFooter);
+      this.$buttonCorrect = H5P.JoubelUI.createButton({
+        'class': 'h5p-dialogcards-answer-button',
+        'html': this.params.correctAnswer
+      }).addClass('correct')
+        .addClass(classesRepetition)
+        .attr('tabindex', attributeTabindex)
+        .appendTo($cardFooter);
+    }
 
     return $cardFooter;
   }
@@ -203,29 +208,31 @@ class Card {
    * Will be lost when the element is removed from DOM.
    */
   createButtonListeners() {
-    this.$buttonIncorrect
-      .unbind('click')
-      .click(event => {
-        if (!event.target.classList.contains('h5p-dialogcards-quick-progression')) {
-          return;
-        }
-        this.callbacks.onNextCard({cardId: this.id, result: false});
-      });
-
     this.$buttonTurn
       .unbind('click')
       .click(() => {
         this.turnCard();
       });
 
-    this.$buttonCorrect
-      .unbind('click')
-      .click(event => {
-        if (!event.target.classList.contains('h5p-dialogcards-quick-progression')) {
-          return;
-        }
-        this.callbacks.onNextCard({cardId: this.id, result: true});
-      });
+    if (this.params.mode === 'repetition') {
+      this.$buttonIncorrect
+        .unbind('click')
+        .click(event => {
+          if (!event.target.classList.contains('h5p-dialogcards-quick-progression')) {
+            return;
+          }
+          this.callbacks.onNextCard({cardId: this.id, result: false});
+        });
+
+      this.$buttonCorrect
+        .unbind('click')
+        .click(event => {
+          if (!event.target.classList.contains('h5p-dialogcards-quick-progression')) {
+            return;
+          }
+          this.callbacks.onNextCard({cardId: this.id, result: true});
+        });
+    }
   }
 
   /**

--- a/src/styles/h5p-dialogcards.css
+++ b/src/styles/h5p-dialogcards.css
@@ -103,6 +103,10 @@
   justify-content: space-between;
 }
 
+.h5p-dialogcards .h5p-dialogcards-cardwrap.h5p-dialogcards-mode-normal .h5p-dialogcards-card-footer {
+  justify-content: center;
+}
+
 .h5p-dialogcards .h5p-dialogcards-image-wrapper {
   position: relative;
 }


### PR DESCRIPTION
When in normal mode, the visibility of the unused buttons for "I got it wrong"/"I got it right" is set to hidden (as it would be for the repetition mode). Thus the buttons still take up space and can lead to the "Turn" button not be be centered if the texts are long and uneven while nobody will ever see those buttons.

When this code is merged in, in normal mode these buttons will not be added to the DOM at all.