### PR TITLE
H5P-3506 Fix tip positioning

### DIFF
--- a/src/styles/h5p-dialogcards.css
+++ b/src/styles/h5p-dialogcards.css
@@ -390,6 +390,13 @@
   font-size: 1.2em;
 }
 
+.h5p-dialogcards .joubel-tip-container::before {
+  left: auto;
+  right: 1.75em;
+  top: 0.25em;
+  transform: none;
+}
+
 .h5p-dialogcards .h5p-dialogcards-cardwrap-set {
   margin: auto;
   max-width: 32em;


### PR DESCRIPTION
Currently, the tooltip of joubelui tip icons will be rendered atop the icon and be partially hidden.

When merged in, the icon's stylesheet will be amended to display the tool tip left of the icon.