### PR TITLE
VA-1069 Use h5p-theme-next style for next button

### DIFF
--- a/src/scripts/h5p-dialogcards-card.js
+++ b/src/scripts/h5p-dialogcards-card.js
@@ -87,7 +87,7 @@ class Card {
       .appendTo($cardTextWrapper);
 
     return $cardContent;
-  } 
+  }
   /**
    * Process HTML escaped string for use as attribute value,
    * e.g. for alt text or title attributes.
@@ -193,7 +193,7 @@ class Card {
 
     if (this.params.mode === 'repetition') {
       this.$buttonShowSummary = $(H5P.Components.Button({
-        classes: 'h5p-dialogcards-show-summary h5p-dialogcards-button-gone h5p-theme-show-results',
+        classes: 'h5p-dialogcards-show-summary h5p-dialogcards-button-gone h5p-results',
         styleType: 'secondary',
         label: this.params.showSummary,
       })).appendTo($cardFooter);

--- a/src/scripts/h5p-dialogcards-card.js
+++ b/src/scripts/h5p-dialogcards-card.js
@@ -193,7 +193,7 @@ class Card {
 
     if (this.params.mode === 'repetition') {
       this.$buttonShowSummary = $(H5P.Components.Button({
-        classes: 'h5p-dialogcards-show-summary h5p-dialogcards-button-gone h5p-results',
+        classes: 'h5p-dialogcards-show-summary h5p-dialogcards-button-gone h5p-theme-results',
         styleType: 'secondary',
         label: this.params.showSummary,
       })).appendTo($cardFooter);

--- a/src/styles/h5p-dialogcards.css
+++ b/src/styles/h5p-dialogcards.css
@@ -289,15 +289,9 @@
   font-weight: normal;
 }
 .h5p-dialogcards .h5p-theme-flip,
-.h5p-dialogcards .h5p-theme-show-results {
+.h5p-dialogcards .h5p-theme-results {
   white-space: nowrap;
   order: 2;
-}
-
-.h5p-dialogcards .h5p-results::before {
-  content: "\e904";
-  font-family: 'h5p-theme';
-  font-weight: normal;
 }
 
 .h5p-dialogcards .h5p-theme-flip {

--- a/src/styles/h5p-dialogcards.css
+++ b/src/styles/h5p-dialogcards.css
@@ -288,10 +288,16 @@
   content: "\e903";
   font-weight: normal;
 }
-.h5p-dialogcards .h5p-theme-flip, 
+.h5p-dialogcards .h5p-theme-flip,
 .h5p-dialogcards .h5p-theme-show-results {
   white-space: nowrap;
   order: 2;
+}
+
+.h5p-dialogcards .h5p-results::before {
+  content: "\e904";
+  font-family: 'h5p-theme';
+  font-weight: normal;
 }
 
 .h5p-dialogcards .h5p-theme-flip {


### PR DESCRIPTION
When merged in, will use the `h5p-theme-next` styling for the "next" button.